### PR TITLE
add warmup run, and a --no-warmup flag

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -25,6 +25,7 @@
 (define verbose-flag? #f)
 (define plot-flag? #f)
 (define single-target? #f)
+(define warmup? #true)
 (define iters 5)
 
 (define-values (control-bin test-bin)
@@ -35,6 +36,8 @@
                        (set! verbose-flag? #t)]
    [("-p" "--plot") "Plot results"
                     (set! plot-flag? #t)]
+   [("--no-warmup") "Skip the warmup run. USE AT YOUR OWN RISK."
+                    (set! warmup? #false)]
    #:multi
    [("-t" "--target") target
                       "Only build a single target"
@@ -94,6 +97,8 @@
 (define (time-dir dir raco)
   (printf "building ~a" dir)
   (flush-output)
+  (when warmup?
+    (void (time-single-build dir raco)))
   (define times (for/list ([_ (in-range iters)])
                   (begin0 (time-single-build dir raco)
                           (printf ".")


### PR DESCRIPTION
Tested this with the `dungeon` benchmark:

1. change any file in typed racket. recompile typed racket
2. run with the `--no-warmup` flag, the first compile-time is very slow
3. change any file in typed racket, recompile TR
4. run without `--no-warmup`, no outlier!

- - -

To avoid confusion like in racket/typed-racket pull request 631, always do a warmup run before measuring compile times.
(Unless the user passes the `--no-warmup` flag.)